### PR TITLE
Set Process type to web/nodejs.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+# bin/release <build-dir>
 
-cat <<EOF
----
+cat << EOF
+addons: []
+default_process_types:
+  web: npm start
 EOF


### PR DESCRIPTION
Deploying failed because process type was not set.
There is a need to set process type to web/`npm start`.

FYI:
https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#viewing-buildpacks
```
The last buildpack in the list will be used to determine the process types for the application. Any process types defined from earlier buildpacks will be ignored.
```