### PR TITLE
Change to use heroku slug hash instead of source version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Define the following configuration variables within Herkou app. See [Heroku Docu
 ## Getting Sentry Auth Token
 
 You can get it on the [API page][]. The token needs the `project:write` scope to be able to upload. The token value would be saved as the `SENTRY_AUTH_TOKEN` configuration variables.
- 
+
 ## Determining your Sentry organziation and project
 
 When viewing your project within Sentry, the organization and project will be found within the URL.
@@ -42,11 +42,11 @@ When using webpack, babel, or uglifyJS, you need to build the sourcemaps before 
 module.exports = {
   webpack(config, { dev }) {
     if (!dev) {
-      config.devtool = 'source-map';
+      config.devtool = "source-map";
     }
 
     return config;
-  },
+  }
 };
 ```
 
@@ -66,24 +66,23 @@ And push a new relase.
 
 ## Defining the Sentry release
 
-The buildpack will use the current git commit number via the environment variable `SOURCE_VERSION` to mark the Sentry release. If you have trouble setting this in you Heroku config or app, I recommend using the [Heroku Buildpack Version](https://github.com/ianpurvis/heroku-buildpack-version) before this buildpack.
+The buildpack will use the current git commit number via the environment variable `HEROKU_SLUG_COMMIT` to mark the Sentry release. More information can be found about this [here](https://devcenter.heroku.com/articles/dyno-metadata).
 
 ## What Changed
 
-This is a modified version of the great work done by *Schnouki* found [here](https://github.com/Schnouki/buildpack-sentry-sourcemaps). Things were changed to be a little more robust, and support more standard configuration variables with Sentry.
+This is a modified version of the great work done by _Schnouki_ found [here](https://github.com/Schnouki/buildpack-sentry-sourcemaps). Things were changed to be a little more robust, and support more standard configuration variables with Sentry.
 
 - Envrioment Variables were changed to match the [Sentry CLI Configuration](https://docs.sentry.io/learn/cli/configuration/) variables. This allowed the buildpack to be a drop-in replacement for WebPack configs, Sentry CLI, and other methods.
 - The prefix Enviroment Variable was deprecated and now defaults to using `~` which means the full domain does not need specified. View the sentry [documentation][docs] for more details on how this work.
 - The original buildpack was great, but would not dig through nested folders. Instead of looking for Source Maps in a single folder, one level deep, it looks through the entire projects directory for source maps. This creates a more universial solution to work across multiple projects. This also means that certain folders are ignored by default, include `node_modules` and `.heroku`.
 
-I did not submit a PR for these changes because of the modification of Enviroment Variables. This means this is considered a breaking change, and can not be used as a drop-in replacement for the work *Schanouki* did.
+I did not submit a PR for these changes because of the modification of Enviroment Variables. This means this is considered a breaking change, and can not be used as a drop-in replacement for the work _Schanouki_ did.
 
 ## License
 
 MIT.
 
-
-[Heroku buildpack]: https://devcenter.heroku.com/articles/buildpacks
-[Sentry]: https://sentry.io/
+[heroku buildpack]: https://devcenter.heroku.com/articles/buildpacks
+[sentry]: https://sentry.io/
 [docs]: https://docs.sentry.io/clients/javascript/sourcemaps/
-[API page]: https://sentry.io/api/
+[api page]: https://sentry.io/api/

--- a/bin/compile
+++ b/bin/compile
@@ -24,19 +24,19 @@ fi
 API="https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}"
 
 # Create a release
-echo "-----> Creating Sentry release ${SOURCE_VERSION} for organization '${SENTRY_ORG}' in project '${SENTRY_PROJECT}'"
+echo "-----> Creating Sentry release ${HEROKU_SLUG_COMMIT} for organization '${SENTRY_ORG}' in project '${SENTRY_PROJECT}'"
 
 curl -sSf "${API}/releases/" \
   -X POST \
   -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
   -H 'Content-Type: application/json' \
-  -d "{\"version\": \"${SOURCE_VERSION}\"}" \
+  -d "{\"version\": \"${HEROKU_SLUG_COMMIT}\"}" \
   >/dev/null
 
 # Retrieve files
 files=$(mktemp)
 echo "       Retrieving existing files to $files"
-curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+curl -sSf "${API}/releases/${HEROKU_SLUG_COMMIT}/files/" \
      -X GET \
      -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
      > "$files"
@@ -60,7 +60,7 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
 
     if [[ "${res[0]}" == "" ]]; then
         echo "       Uploading ${map} to Sentry"
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+        curl -sSf "${API}/releases/${HEROKU_SLUG_COMMIT}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
              -F file=@"${map}" \
@@ -69,11 +69,11 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
 
     elif [[ "${res[1]}" != "${sum}" ]]; then
         echo "       Updating ${map} on Sentry"
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/${res[0]}/" \
+        curl -sSf "${API}/releases/${HEROKU_SLUG_COMMIT}/files/${res[0]}/" \
              -X DELETE \
              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
              >/dev/null
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+        curl -sSf "${API}/releases/${HEROKU_SLUG_COMMIT}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
              -F file=@"${map}" \


### PR DESCRIPTION
This sets the release version in Sentry to the current Heroku slug commit hash instead of the git commit hash.